### PR TITLE
Default to use http scheme when use_ssl is false in spark-connect-rs

### DIFF
--- a/core/src/client/mod.rs
+++ b/core/src/client/mod.rs
@@ -64,7 +64,10 @@ impl ChannelBuilder {
     }
 
     pub fn endpoint(&self) -> String {
-        format!("https://{}:{}", self.host, self.port)
+        if (self.use_ssl) {
+            return format!("https://{}:{}", self.host, self.port);
+        }
+        format!("http://{}:{}", self.host, self.port)
     }
 
     pub fn token(&self) -> Option<String> {

--- a/core/src/errors.rs
+++ b/core/src/errors.rs
@@ -19,7 +19,7 @@ pub enum SparkError {
     IoError(String, std::io::Error),
     ArrowError(ArrowError),
     InvalidConnectionUrl(String),
-    FailedToCreateGrpcChannel(TonicTransportError),
+    TonicTransportError(TonicTransportError),
 }
 
 impl SparkError {
@@ -53,6 +53,12 @@ impl From<ArrowError> for SparkError {
     }
 }
 
+impl From<TonicTransportError> for SparkError {
+    fn from(error: TonicTransportError) -> Self {
+        SparkError::TonicTransportError(error)
+    }
+}
+
 impl From<tonic::Status> for SparkError {
     fn from(status: tonic::Status) -> Self {
         SparkError::AnalysisException(status.message().to_string())
@@ -80,8 +86,8 @@ impl Display for SparkError {
             SparkError::ArrowError(desc) => write!(f, "Apache Arrow error: {desc}"),
             SparkError::NotYetImplemented(source) => write!(f, "Not yet implemented: {source}"),
             SparkError::InvalidConnectionUrl(val) => write!(f, "Invalid URL error: {val}"),
-            SparkError::FailedToCreateGrpcChannel(source) => {
-                write!(f, "Failed to create channel: {source}")
+            SparkError::TonicTransportError(source) => {
+                write!(f, "Tonic Transport Error: {source}")
             }
         }
     }

--- a/core/src/errors.rs
+++ b/core/src/errors.rs
@@ -87,7 +87,7 @@ impl Display for SparkError {
             SparkError::NotYetImplemented(source) => write!(f, "Not yet implemented: {source}"),
             SparkError::InvalidConnectionUrl(val) => write!(f, "Invalid URL error: {val}"),
             SparkError::TonicTransportError(source) => {
-                write!(f, "Tonic Transport Error: {source}")
+                write!(f, "Tonic Transport error: {source}")
             }
         }
     }

--- a/core/src/errors.rs
+++ b/core/src/errors.rs
@@ -7,6 +7,8 @@ use std::error::Error;
 
 use arrow::error::ArrowError;
 
+use tonic::transport::Error;
+
 /// Different `Spark` types
 #[derive(Debug)]
 pub enum SparkError {
@@ -17,6 +19,7 @@ pub enum SparkError {
     IoError(String, std::io::Error),
     ArrowError(ArrowError),
     InvalidConnectionUrl(String),
+    FailedToCreateGrpcChannel(tonic::transport::Error),
 }
 
 impl SparkError {
@@ -77,6 +80,9 @@ impl Display for SparkError {
             SparkError::ArrowError(desc) => write!(f, "Apache Arrow error: {desc}"),
             SparkError::NotYetImplemented(source) => write!(f, "Not yet implemented: {source}"),
             SparkError::InvalidConnectionUrl(val) => write!(f, "Invalid URL error: {val}"),
+            SparkError::FailedToCreateGrpcChannel(source) => {
+                write!(f, "Failed to create channel: {source}")
+            }
         }
     }
 }

--- a/core/src/errors.rs
+++ b/core/src/errors.rs
@@ -7,7 +7,7 @@ use std::error::Error;
 
 use arrow::error::ArrowError;
 
-use tonic::transport::Error;
+use tonic::transport::Error as TonicTransportError;
 
 /// Different `Spark` types
 #[derive(Debug)]
@@ -19,7 +19,7 @@ pub enum SparkError {
     IoError(String, std::io::Error),
     ArrowError(ArrowError),
     InvalidConnectionUrl(String),
-    FailedToCreateGrpcChannel(tonic::transport::Error),
+    FailedToCreateGrpcChannel(TonicTransportError),
 }
 
 impl SparkError {

--- a/core/src/session.rs
+++ b/core/src/session.rs
@@ -61,8 +61,7 @@ impl SparkSessionBuilder {
         let channel = Endpoint::from_shared(self.channel_builder.endpoint())
             .expect("Failed to create endpoint")
             .connect()
-            .await
-            .expect("Failed to create channel");
+            .await?;
 
         let service_client = SparkConnectServiceClient::with_interceptor(
             channel,


### PR DESCRIPTION
* Default the scheme to http when use_ssl is false
* Not panic when transport channel cannot be created
* Create a new TonicTransportError SparkError variant to handle failure in creating transport channel
Tested with Databricks and Spark localhost connection, both works well