### PR TITLE
Use native certificate roots for TLS connections

### DIFF
--- a/core/src/client/mod.rs
+++ b/core/src/client/mod.rs
@@ -70,6 +70,10 @@ impl ChannelBuilder {
         format!("http://{}:{}", self.host, self.port)
     }
 
+    pub fn use_ssl(&self) -> bool {
+        self.use_ssl
+    }
+
     pub fn token(&self) -> Option<String> {
         self.token.to_owned()
     }


### PR DESCRIPTION
# Description
When `use_ssl` is `true`, load the system certificate roots for TLS connections.

The latest version of `tonic` disabled this by default in https://github.com/hyperium/tonic/pull/1731