### PR TITLE
Support dynamic token update for `SparkSession`

### DIFF
--- a/core/src/client/mod.rs
+++ b/core/src/client/mod.rs
@@ -198,7 +198,7 @@ impl ChannelBuilder {
             .unwrap_or_else(|| ChannelBuilder::create_user_agent(None));
 
         if let Some(token) = headers.remove("token") {
-            channel_builder.token = Some(format!("Bearer {token}"));
+            channel_builder.token = Some(token);
         }
 
         if let Some(session_id) = headers.remove("session_id") {
@@ -259,7 +259,7 @@ impl Interceptor for MetadataInterceptor {
         if let Some(token) = token.get_value() {
             req.metadata_mut().insert(
                 "authorization",
-                AsciiMetadataValue::from_str(token).unwrap(),
+                AsciiMetadataValue::from_str(format!("Bearer {token}").as_str()).unwrap(),
             );
         }
 

--- a/core/src/session.rs
+++ b/core/src/session.rs
@@ -93,7 +93,6 @@ impl SparkSessionBuilder {
 
         let channel = endpoint.connect().await?;
 
-        // channel builder returns token with `Bearer` prefix
         let token = Arc::new(RwLock::new(Token::new(
             self.channel_builder.token().clone(),
         )));
@@ -391,7 +390,7 @@ impl SparkSession {
 
     pub fn set_token(&self, token: Option<&str>) {
         let mut guard = self.token.write();
-        guard.set_value(token.map(|t| format!("Bearer {}", t)).as_deref());
+        guard.set_value(token);
     }
 }
 
@@ -410,7 +409,7 @@ mod tests {
             ssbuilder.channel_builder.endpoint()
         );
         assert_eq!(
-            "Bearer ABCDEFG".to_string(),
+            "ABCDEFG".to_string(),
             ssbuilder.channel_builder.token().unwrap()
         );
     }


### PR DESCRIPTION
# Description

This pull request introduces a new `Token` struct to manage authorization tokens more effectively and integrates it into the `MetadataInterceptor` and `SparkSession` components. This allows to update the token value at runtime, without recreating the session, and ensures consistent token handling across the client and session layers.

### Token Management Enhancements:
* Added a new `Token` struct with methods to initialize, retrieve, and update token values, replacing the previous `Option<String>` approach for token handling in `MetadataInterceptor`.
* Updated `MetadataInterceptor` to use a thread-safe `Arc<RwLock<Token>>` for token storage, allowing concurrent read/write access to the token.
* Moved Bearer prefix handling from channel builder to interceptor.

### Integration with `SparkSession`:
* Modified the `SparkSession` struct to include a `token` field of type `Arc<RwLock<Token>>`, enabling centralized token management within the session.
* Added a public `set_token` method to `SparkSession` to allow runtime updates to the token value, supporting dynamic token refresh flow.

### Example Usage:
```rust
// build session from connection string
let token = "<..>"; // initial access token
let connection = format!(
  "sc://{endpoint}:443/;use_ssl={databricks_use_ssl};user_id=spice.ai;session_id={session_id};token={token};x-databricks-cluster-id={cluster_id}"
);
let session = SparkSessionBuilder::remote(connection)?.build().await?;

// <...>

// set refreshed token
session.set_token(Some(refreshed_token));

```

# Related Issue(s)
- closes https://github.com/spiceai/spiceai/issues/5480

# Documentation

<!---
Share links to useful documentation
--->
